### PR TITLE
Update CM command doc with relevant syntax

### DIFF
--- a/docs/selenoid-commands.adoc
+++ b/docs/selenoid-commands.adoc
@@ -102,7 +102,7 @@ To see supported flags for each command append `--help`:
 +
 [source,bash]
 ----
-./cm selenoid download [--version 1.2.1] [--force]
+./cm selenoid download --version "1.9.1" --force
 ----
 +
 This command does nothing when already downloaded. Use `--force` flag to download again.
@@ -112,7 +112,7 @@ This command does nothing when already downloaded. Use `--force` flag to downloa
 +
 [source,bash]
 ----
-./cm selenoid configure [--browsers firefox:>45.0;opera:53.0;android] [--last-versions 2] [--tmpfs 128]
+./cm selenoid configure --browsers "firefox:>45.0;opera:53.0;android" --last-versions 2 --tmpfs 128
 ----
 +    
 Use `--browsers` to limit browsers to be configured, `--tmpfs` - to add https://en.wikipedia.org/wiki/Tmpfs[Tmpfs] support, `--last-versions` - to limit how many last browser versions to download. If you wish to download all available versions - specify `--last-versions 0`.
@@ -126,7 +126,14 @@ Use `--browsers` to limit browsers to be configured, `--tmpfs` - to add https://
 ----
 +    
 By default Selenoid data is stored in `~/.aerokube/selenoid` but you can specify another
-directory using `--config-dir` flag. To download images with VNC server (to see live browser screen) use `--vnc` flag:
+directory using `--config-dir` flag:
++
+[source,bash]
+----
+./cm selenoid start --config-dir /path/to/dir
+----
++
+To download images with VNC server (to see live browser screen) use `--vnc` flag:
 +
 [source,bash]
 ----


### PR DESCRIPTION
In the latest stable version of the CM binary, if arguments are enclosed
with the square brackets, then these arguments are ignored. They have to
be put within quotes.
Also, add an example of the `--config-dir` command.