### PR TITLE
Bugfix: --whitelisted-ips must be blank to avoid error with Chromedriver

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -1,6 +1,6 @@
 {
   "chrome": {
-    "command": "%s --whitelisted-ips='' --verbose",
+    "command": "%s --whitelisted-ips= --verbose",
     "files": {
       "linux": {
         "amd64": {
@@ -26,7 +26,7 @@
       }
     }
   },
-  
+
   "firefox": {
     "command": "%s --host 127.0.0.1 --log debug",
     "files": {
@@ -58,7 +58,7 @@
       }
     }
   },
-  
+
   "opera": {
     "command": "%s --whitelisted-ips='' --verbose",
     "files": {
@@ -87,7 +87,7 @@
 
     }
   },
-  
+
   "safari": {
     "command": "%s",
     "files": {
@@ -115,7 +115,7 @@
       }
     }
   },
-  
+
   "MicrosoftEdge": {
     "command": "%s --host=127.0.0.1 --verbose",
     "files": {


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What this PR does / why we need it:

When cm is used to configure Selenoid, it sets `--whitelisted-ips=''` for Chrome in browsers.json which causes an error:

```
$ selenoid -conf browsers.json -disable-docker -disable-queue -capture-driver-logs

2019/05/29 22:52:34 [-] [INIT] [Loading configuration files...]
2019/05/29 22:52:34 [-] [INIT] [Loaded configuration from browsers.json]
2019/05/29 22:52:34 [-] [INIT] [Timezone: Local]
2019/05/29 22:52:34 [-] [INIT] [Listening on :4444]
2019/05/29 22:52:36 [-] [NEW_REQUEST] [unknown] [127.0.0.1]
2019/05/29 22:52:36 [-] [NEW_REQUEST_ACCEPTED] [unknown] [127.0.0.1]
2019/05/29 22:52:36 [0] [LOCATING_SERVICE] [chrome] []
2019/05/29 22:52:36 [-] [DEFAULT_VERSION] [Using default version: latest]
2019/05/29 22:52:36 [0] [USING_DRIVER] [chrome] [latest]
2019/05/29 22:52:36 [0] [ALLOCATING_PORT]
2019/05/29 22:52:36 [0] [ALLOCATED_PORT] [37235]
2019/05/29 22:52:36 [0] [STARTING_PROCESS] [[.aerokube/selenoid/chromedriver --whitelisted-ips='' --verbose --port=37235]]
Invalid IP address ''. Exiting...
```

This PR fixes browsers.json so Chromedriver runs correctly.
