### PR TITLE
fix: split video args

### DIFF
--- a/selenoid/docker.go
+++ b/selenoid/docker.go
@@ -718,9 +718,11 @@ func (c *DockerConfigurator) Start() error {
 		cmd = append(cmd, "-conf", "/etc/selenoid/browsers.json")
 	}
 	if !contains(cmd, "-video-output-dir") && isVideoRecordingSupported(c.Logger, c.Version) {
-		cmd = append(cmd, "-video-output-dir", "/opt/selenoid/video/", "-video-recorder-image", videoRecorderImage)
+		cmd = append(cmd, "-video-output-dir", "/opt/selenoid/video/")
 	}
-
+	if !contains(cmd, "-video-recorder-image") && isVideoRecordingSupported(c.Logger, c.Version) {
+		cmd = append(cmd, "-video-recorder-image", videoRecorderImage)
+	}
 	if !c.DisableLogs && !contains(cmd, "-log-output-dir") && isLogSavingSupported(c.Logger, c.Version) {
 		cmd = append(cmd, "-log-output-dir", "/opt/selenoid/logs/")
 	}


### PR DESCRIPTION
if usage
`cm selenoid start --vnc --tmpfs 128 --args "-video-recorder-image docker.io/selenoid/video-recorder:7.1"`
to arg video-recorder-image dublicate need usage
`cm selenoid start --vnc --tmpfs 128 --args "-video-recorder-image docker.io/selenoid/video-recorder:7.1 -video-output-dir /opt/selenoid/video/"`
this incorrect work